### PR TITLE
Redirworkers

### DIFF
--- a/docs/sxhost-locally-originated-traffic.md
+++ b/docs/sxhost-locally-originated-traffic.md
@@ -1,0 +1,71 @@
+# Inspecting smithproxy locally originated traffic
+
+This is a mini-howto describing how to set up smithproxy inspection for locally originated traffic.  
+
+## Scenario
+
+```
++-- SX host -----+  
+|                |  
+|   [smithproxy] |  
+|                |  
+|   [your app]---------------> OUT    
+|                |  
++----------------+  
+```
+
+## TCP traffic
+
+This is possible with some limitations by utilizing OUTPUT iptables chain. Only limitation is  we cannot in default 
+installation divert `root` user traffic.  
+Because smithproxy is originating traffic on behalf of depicted `your app`, it would hit again OUTPUT chain and create
+a loop.  That's the reason why we need to distinguish traffic not intended for further redirection. user-id is the 
+simplest way to do it.  
+> **If you *need* to inspect root user traffic, this scenario is not possible to follow.**   
+>  Only solution is to run smithproxy as different user with root privileges, but it's not implemented yet.     
+
+Smithproxy listens by default on `51080` (plain) and `51443` (tls) ports for incoming redirected traffic. Please don't 
+use tproxy ports, it will not work.  
+
+How to divert local tcp traffic to smithproxy:  
+  
+``` 
+iptables -t nat -A OUTPUT -p tcp -d 0.0.0.0/0 --dport 80 -j REDIRECT --to-port 51080 -m owner ! --uid-owner root 
+iptables -t nat -A OUTPUT -p tcp -d 0.0.0.0/0 --dport 443 -j REDIRECT --to-port 51443 -m owner ! --uid-owner root
+```
+
+
+## UDP traffic
+
+UDP output chain redirection is problematic for smithproxy and similar applications. Original destination IP address is 
+possible to extract only on fully connected UDP socket. Smithproxy (and others) can't use fully connected UDP sockets.  
+Because of such a technical limitation
+> Smithproxy supports UDP only for DNS, sending traffic to preconfigured DNS servers. Also, only non-root user 
+> traffic shall be diverted to smithproxy.
+    
+
+Example of diverting locally originated DNS: 
+```     
+iptables -t nat -A OUTPUT -p udp -d 8.8.4.4 --dport 53 -j REDIRECT --to-port 51053 -m owner ! --uid-owner root                        
+iptables -t nat -A OUTPUT -p udp -d 8.8.8.8 --dport 53 -j REDIRECT --to-port 51053 -m owner ! --uid-owner root   
+```
+
+Such a traffic is then sent to congfigured DNS, see `smithproxy.cfg`:
+```
+settings = {
+   nameservers = ("8.8.8.8", "8.8.4.4");
+   // ... 
+```
+
+
+## Conclusion
+
+With some limitations, locally originated TCP and DNS traffic can be **transparently** inspected, without configuring 
+the end application. 
+
+Both conditions must be met:
+
+* traffic must not be owned by root
+* UDP is considered as DNS traffic and is sent to preconfigured nameservers in `smithproxy.cfg` 
+
+

--- a/src/proxy/mitmproxy.hpp
+++ b/src/proxy/mitmproxy.hpp
@@ -205,7 +205,7 @@ private:
 class MitmMasterProxy : public ThreadedAcceptorProxy<MitmProxy> {
 public:
     
-    MitmMasterProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type t = proxy_type::TRANSPARENT) :
+    MitmMasterProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type_t t = proxy_type_t::TRANSPARENT) :
         ThreadedAcceptorProxy< MitmProxy >(c,worker_id, t) {
 
         log.area("acceptor.tcp");
@@ -226,7 +226,7 @@ public:
 
 class MitmUdpProxy : public ThreadedReceiverProxy<MitmProxy> {
 public:
-    MitmUdpProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type t = proxy_type::TRANSPARENT):
+    MitmUdpProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type_t t = proxy_type_t::TRANSPARENT):
         ThreadedReceiverProxy< MitmProxy >(c,worker_id, t) {
 
         log.area("acceptor.udp");

--- a/src/proxy/mitmproxy.hpp
+++ b/src/proxy/mitmproxy.hpp
@@ -202,11 +202,12 @@ private:
     logan_attached<MitmProxy> log;
 };
 
-
 class MitmMasterProxy : public ThreadedAcceptorProxy<MitmProxy> {
 public:
     
-    MitmMasterProxy(baseCom* c, int worker_id) : ThreadedAcceptorProxy< MitmProxy >(c,worker_id) {
+    MitmMasterProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type t = proxy_type::TRANSPARENT) :
+        ThreadedAcceptorProxy< MitmProxy >(c,worker_id, t) {
+
         log.area("acceptor.tcp");
     };
     
@@ -225,7 +226,9 @@ public:
 
 class MitmUdpProxy : public ThreadedReceiverProxy<MitmProxy> {
 public:
-    MitmUdpProxy(baseCom* c, int worker_id) : ThreadedReceiverProxy< MitmProxy >(c,worker_id) {
+    MitmUdpProxy(baseCom* c, int worker_id, threadedProxyWorker::proxy_type t = proxy_type::TRANSPARENT):
+        ThreadedReceiverProxy< MitmProxy >(c,worker_id, t) {
+
         log.area("acceptor.udp");
     };
     virtual void on_left_new(baseHostCX* just_accepted_cx);

--- a/src/proxy/socks5/socksproxy.hpp
+++ b/src/proxy/socks5/socksproxy.hpp
@@ -68,8 +68,9 @@ private:
 
 class MitmSocksProxy : public ThreadedAcceptorProxy<SocksProxy> {
 public:
+    using proxy_type = threadedProxyWorker::proxy_type;
 
-    MitmSocksProxy(baseCom* c, int worker_id) : ThreadedAcceptorProxy<SocksProxy>(c,worker_id) {
+    MitmSocksProxy(baseCom* c, int worker_id, proxy_type t = proxy_type::PROXY) : ThreadedAcceptorProxy<SocksProxy>(c,worker_id, t) {
         log = logan::attach(this, "masterproxy.socks");
     };
     baseHostCX* new_cx(int s) override;

--- a/src/proxy/socks5/socksproxy.hpp
+++ b/src/proxy/socks5/socksproxy.hpp
@@ -68,7 +68,7 @@ private:
 
 class MitmSocksProxy : public ThreadedAcceptorProxy<SocksProxy> {
 public:
-    using proxy_type = threadedProxyWorker::proxy_type;
+    using proxy_type = threadedProxyWorker::proxy_type_t;
 
     MitmSocksProxy(baseCom* c, int worker_id, proxy_type t = proxy_type::PROXY) : ThreadedAcceptorProxy<SocksProxy>(c,worker_id, t) {
         log = logan::attach(this, "masterproxy.socks");

--- a/src/service/smithd/smithd.cpp
+++ b/src/service/smithd/smithd.cpp
@@ -187,7 +187,7 @@ DEFINE_LOGGING(SmithdProxy);
 
 class UxAcceptor : public ThreadedAcceptorProxy<SmithdProxy> {
 public:
-    UxAcceptor(baseCom* c, int worker_id, proxy_type t = proxy_type::NONE ) :
+    UxAcceptor(baseCom* c, int worker_id, proxy_type_t t = proxy_type_t::NONE ) :
         ThreadedAcceptorProxy<SmithdProxy>(c,worker_id, t) {};
     
     baseHostCX* new_cx(const char* h, const char* p) override { return new SmithServerCX(com()->slave(),h,p); };

--- a/src/service/smithd/smithd.cpp
+++ b/src/service/smithd/smithd.cpp
@@ -187,7 +187,8 @@ DEFINE_LOGGING(SmithdProxy);
 
 class UxAcceptor : public ThreadedAcceptorProxy<SmithdProxy> {
 public:
-    UxAcceptor(baseCom* c, int worker_id) : ThreadedAcceptorProxy<SmithdProxy>(c,worker_id) {};
+    UxAcceptor(baseCom* c, int worker_id, proxy_type t = proxy_type::NONE ) :
+        ThreadedAcceptorProxy<SmithdProxy>(c,worker_id, t) {};
     
     baseHostCX* new_cx(const char* h, const char* p) override { return new SmithServerCX(com()->slave(),h,p); };
     baseHostCX* new_cx(int s) override { return new SmithServerCX(com()->slave(), s); };
@@ -583,7 +584,12 @@ int main(int argc, char *argv[]) {
     backend_proxy = nullptr;
 
     try {
-        ServiceFactory::prepare_listener<UxProxy,UxCom>(cfg_smithd_listen_port,"ux-plain","/var/run/smithd.sock",cfg_smithd_workers);
+        ServiceFactory::prepare_listener<UxProxy,UxCom>(
+                cfg_smithd_listen_port,
+                "ux-plain",
+                "/var/run/smithd.sock",
+                cfg_smithd_workers,
+                ServiceFactory::proxy_type::NONE);
     } catch(socle::com_error const& e) {
         _fat("Exception caught when creating listener: %s", e.what());
         backend_proxy = nullptr;

--- a/src/service/smithproxy.cpp
+++ b/src/service/smithproxy.cpp
@@ -162,7 +162,7 @@ void SmithProxy::create_listeners() {
 
     redir_udp_proxy = ServiceFactory::prepare_listener<theReceiver, UDPCom>(
             std::stoi(CfgFactory::get().listen_udp_port) + 1000,
-            "udp",
+            "udp-rdr",
             CfgFactory::get().num_workers_udp,
             ServiceFactory::proxy_type::REDIRECT);
 

--- a/src/service/smithproxy.cpp
+++ b/src/service/smithproxy.cpp
@@ -122,36 +122,56 @@ void SmithProxy::create_identity_thread() {
 
 void SmithProxy::create_listeners() {
     plain_proxy = ServiceFactory::prepare_listener<theAcceptor, TCPCom>(std::stoi(CfgFactory::get().listen_tcp_port),
-                            "plain-text",
+                            "plain-tcp",
                             50080,
-                            CfgFactory::get().num_workers_tcp);
+                            CfgFactory::get().num_workers_tcp,
+                            ServiceFactory::proxy_type::TRANSPARENT);
 
     ssl_proxy = ServiceFactory::prepare_listener<theAcceptor, MySSLMitmCom>(std::stoi(CfgFactory::get().listen_tls_port),
-                            "SSL",
+                            "tls",
                             50443,
-                            CfgFactory::get().num_workers_tls);
+                            CfgFactory::get().num_workers_tls,
+                            ServiceFactory::proxy_type::TRANSPARENT);
 
     dtls_proxy = ServiceFactory::prepare_listener<theReceiver, MyDTLSMitmCom>(std::stoi(CfgFactory::get().listen_dtls_port),
-                            "DTLS",
+                            "dtls",
                             50443,
-                            CfgFactory::get().num_workers_dtls);
+                            CfgFactory::get().num_workers_dtls,
+                            ServiceFactory::proxy_type::TRANSPARENT);
 
     udp_proxy = ServiceFactory::prepare_listener<theReceiver, UDPCom>(std::stoi(CfgFactory::get().listen_udp_port),
-                            "plain-udp",
+                            "udp",
                             50080,
-                            CfgFactory::get().num_workers_udp);
+                            CfgFactory::get().num_workers_udp,
+                            ServiceFactory::proxy_type::TRANSPARENT);
 
     socks_proxy = ServiceFactory::prepare_listener<socksAcceptor, socksTCPCom>(std::stoi(CfgFactory::get().listen_socks_port),
                             "socks",
                             1080,
-                            CfgFactory::get().num_workers_socks);
+                            CfgFactory::get().num_workers_socks,
+                            ServiceFactory::proxy_type::PROXY);
+
+    redir_plain_proxy = ServiceFactory::prepare_listener<theAcceptor, TCPCom>(51080,
+                            "plain-rdr",
+                            51080,
+                            CfgFactory::get().num_workers_tcp,
+                            ServiceFactory::proxy_type::REDIRECT);
+    redir_ssl_proxy = ServiceFactory::prepare_listener<theAcceptor, MySSLMitmCom>(51443,
+                            "ssl-rdr",
+                            51443,
+                            CfgFactory::get().num_workers_tcp,
+                            ServiceFactory::proxy_type::REDIRECT);
+
 
 
     if ((plain_proxy == nullptr && CfgFactory::get().num_workers_tcp >= 0) ||
         (ssl_proxy == nullptr && CfgFactory::get().num_workers_tls >= 0) ||
         (dtls_proxy == nullptr && CfgFactory::get().num_workers_dtls >= 0) ||
         (udp_proxy == nullptr && CfgFactory::get().num_workers_udp >= 0) ||
-        (socks_proxy == nullptr && CfgFactory::get().num_workers_socks >= 0)) {
+        (socks_proxy == nullptr && CfgFactory::get().num_workers_socks >= 0) ||
+        (redir_plain_proxy == nullptr && CfgFactory::get().num_workers_tcp >= 0) ||
+        (redir_ssl_proxy == nullptr && CfgFactory::get().num_workers_tls >= 0)
+       ) {
 
         _fat("Failed to setup proxies. Bailing!");
         exit(-1);
@@ -168,6 +188,8 @@ void SmithProxy::run() {
     std::string friendly_thread_name_cli = string_format("sxy_cli_%d",CfgFactory::get().tenant_index);
     std::string friendly_thread_name_own = string_format("sxy_own_%d",CfgFactory::get().tenant_index);
 
+    std::string friendly_thread_name_redir_tcp = string_format("sxy_rdt_%d",CfgFactory::get().tenant_index);
+    std::string friendly_thread_name_redir_ssl = string_format("sxy_rds_%d",CfgFactory::get().tenant_index);
 
     if(plain_proxy) {
         _inf("Starting TCP listener");
@@ -254,6 +276,40 @@ void SmithProxy::run() {
             SmithProxy::instance().socks_proxy->shutdown();
         } );
         pthread_setname_np(socks_thread->native_handle(),friendly_thread_name_skx.c_str());
+    }
+
+    if(redir_plain_proxy) {
+        _inf("Starting REDIR-TCP listener");
+        redir_plain_thread = new std::thread([] () {
+            auto this_daemon = DaemonFactory::instance();
+            auto& log = this_daemon.log;
+
+            this_daemon.set_daemon_signals(SmithProxy::instance().terminate_handler_, SmithProxy::instance().reload_handler_);
+            this_daemon.set_limit_fd(0);
+            _dia("smithproxy_redir_plain: max file descriptors: %d", this_daemon.get_limit_fd());
+
+            SmithProxy::instance().redir_plain_proxy->run();
+            _dia("redir-plain workers torn down.");
+            SmithProxy::instance().redir_plain_proxy->shutdown();
+        } );
+        pthread_setname_np(redir_plain_thread->native_handle(),friendly_thread_name_skx.c_str());
+    }
+
+    if(redir_ssl_proxy) {
+        _inf("Starting REDIR-SSL listener");
+        redir_ssl_thread = new std::thread([] () {
+            auto this_daemon = DaemonFactory::instance();
+            auto& log = this_daemon.log;
+
+            this_daemon.set_daemon_signals(SmithProxy::instance().terminate_handler_, SmithProxy::instance().reload_handler_);
+            this_daemon.set_limit_fd(0);
+            _dia("smithproxy_redir_ssl: max file descriptors: %d", this_daemon.get_limit_fd());
+
+            SmithProxy::instance().redir_ssl_proxy->run();
+            _dia("redir-ssl workers torn down.");
+            SmithProxy::instance().redir_ssl_proxy->shutdown();
+        } );
+        pthread_setname_np(redir_ssl_thread->native_handle(),friendly_thread_name_skx.c_str());
     }
 
     cli_thread = new std::thread([] () {

--- a/src/service/smithproxy.cpp
+++ b/src/service/smithproxy.cpp
@@ -161,7 +161,7 @@ void SmithProxy::create_listeners() {
             ServiceFactory::proxy_type::REDIRECT);
 
     redir_udp_proxy = ServiceFactory::prepare_listener<theReceiver, UDPCom>(
-            std::stoi(CfgFactory::get().listen_udp_port) + 1000,
+            std::stoi(CfgFactory::get().listen_udp_port) + 973,  // 973 + default 50080 = 51053: should suggest DNS only
             "udp-rdr",
             CfgFactory::get().num_workers_udp,
             ServiceFactory::proxy_type::REDIRECT);

--- a/src/service/smithproxy.hpp
+++ b/src/service/smithproxy.hpp
@@ -88,6 +88,7 @@ public:
 
     theAcceptor* redir_plain_proxy = nullptr;
     theAcceptor* redir_ssl_proxy = nullptr;
+    theReceiver* redir_udp_proxy = nullptr;
 
 
     std::thread* plain_thread = nullptr;
@@ -101,6 +102,7 @@ public:
     std::thread* id_thread = nullptr;
     std::thread* redir_plain_thread = nullptr;
     std::thread* redir_ssl_thread = nullptr;
+    std::thread* redir_udp_thread = nullptr;
 
 
     SmithProxy (SmithProxy const&) = delete;

--- a/src/service/smithproxy.hpp
+++ b/src/service/smithproxy.hpp
@@ -86,6 +86,9 @@ public:
     theReceiver* dtls_proxy = nullptr;
     socksAcceptor* socks_proxy = nullptr;
 
+    theAcceptor* redir_plain_proxy = nullptr;
+    theAcceptor* redir_ssl_proxy = nullptr;
+
 
     std::thread* plain_thread = nullptr;
     std::thread* ssl_thread = nullptr;
@@ -96,6 +99,9 @@ public:
     std::thread* log_thread = nullptr;
     std::thread* dns_thread = nullptr;
     std::thread* id_thread = nullptr;
+    std::thread* redir_plain_thread = nullptr;
+    std::thread* redir_ssl_thread = nullptr;
+
 
     SmithProxy (SmithProxy const&) = delete;
     SmithProxy& operator= (SmithProxy const& r) = delete;

--- a/src/service/srvutils.hpp
+++ b/src/service/srvutils.hpp
@@ -45,7 +45,7 @@
 class ServiceFactory {
 public:
 
-    using proxy_type = threadedProxyWorker::proxy_type;
+    using proxy_type = threadedProxyWorker::proxy_type_t;
 
     static logan_lite& log() {
         static logan_lite l("service");

--- a/src/service/srvutils.hpp
+++ b/src/service/srvutils.hpp
@@ -53,13 +53,15 @@ public:
     }
 
     template <class Listener, class Com>
-    static Listener* prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers, proxy_type type);
+    static Listener *
+    prepare_listener (unsigned int port, std::string const &friendly_name, int sub_workers, proxy_type type);
     template <class Listener, class Com>
     static Listener* prepare_listener(std::string const& str_path, std::string const& friendly_name, std::string const& def_path, int sub_workers, proxy_type type);
 };
 
 template <class Listener, class Com>
-Listener* ServiceFactory::prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers, proxy_type type) {
+Listener * ServiceFactory::prepare_listener (unsigned int port, std::string const &friendly_name, int sub_workers,
+                                             proxy_type type) {
 
     auto log = ServiceFactory::log();
 

--- a/src/service/srvutils.hpp
+++ b/src/service/srvutils.hpp
@@ -44,19 +44,22 @@
 
 class ServiceFactory {
 public:
+
+    using proxy_type = threadedProxyWorker::proxy_type;
+
     static logan_lite& log() {
         static logan_lite l("service");
         return l;
     }
 
     template <class Listener, class Com>
-    static Listener* prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers);
+    static Listener* prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers, proxy_type type);
     template <class Listener, class Com>
-    static Listener* prepare_listener(std::string const& str_path, std::string const& friendly_name, std::string const& def_path, int sub_workers);
+    static Listener* prepare_listener(std::string const& str_path, std::string const& friendly_name, std::string const& def_path, int sub_workers, proxy_type type);
 };
 
 template <class Listener, class Com>
-Listener* ServiceFactory::prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers) {
+Listener* ServiceFactory::prepare_listener(unsigned int port, std::string const& friendly_name, int def_port, int sub_workers, proxy_type type) {
 
     auto log = ServiceFactory::log();
 
@@ -65,7 +68,7 @@ Listener* ServiceFactory::prepare_listener(unsigned int port, std::string const&
     }
 
     _not("Entering %s mode on port %d", friendly_name.c_str(), port);
-    auto s_p = new Listener(new Com());
+    auto s_p = new Listener(new Com(), type);
     s_p->com()->nonlocal_dst(true);
     s_p->worker_count_preference(sub_workers);
 
@@ -85,7 +88,7 @@ Listener* ServiceFactory::prepare_listener(unsigned int port, std::string const&
 }
 
 template <class Listener, class Com>
-Listener* ServiceFactory::prepare_listener(std::string const& str_path, std::string const& friendly_name, std::string const& def_path, int sub_workers) {
+Listener* ServiceFactory::prepare_listener(std::string const& str_path, std::string const& friendly_name, std::string const& def_path, int sub_workers, proxy_type type) {
 
     auto log = ServiceFactory::log();
 
@@ -99,7 +102,7 @@ Listener* ServiceFactory::prepare_listener(std::string const& str_path, std::str
     }
     
     _not("Entering %s mode on port %s",friendly_name.c_str(),path.c_str());
-    auto s_p = new Listener(new Com());
+    auto s_p = new Listener(new Com(), type);
     s_p->com()->nonlocal_dst(true);
     s_p->worker_count_preference(sub_workers);
 


### PR DESCRIPTION
```
add a feature supporting iptables REDIRECT for OUTPUT chain.
- TCP/TLS fully supported (plaintext to 51080, tls to 51443)
- UDP works only for DNS due to technical reasons (redirected UDP traffic  will be sent to nameservers)
  There might be a possibility in the future to implement more generic approach for UDP, but we will  
  always need  to specify redirport->target:dport
```